### PR TITLE
PMGR-12007 Update deprecated File.exists usage

### DIFF
--- a/lib/acts_as_flying_saucer/xhtml2pdf.rb
+++ b/lib/acts_as_flying_saucer/xhtml2pdf.rb
@@ -6,7 +6,7 @@ module ActsAsFlyingSaucer
 	class Xhtml2Pdf
 		def self.write_pdf(options)
 
-			if 	!File.exists?(options[:input_file])
+			if 	!File.exist?(options[:input_file])
 				File.open(options[:input_file], 'w') do |file|
 					file << options[:html]
 				end


### PR DESCRIPTION
Looks like the underlying library has gone completely unmaintained (last update 12 years ago). Do we want to try and find a replacement or just keep updating our fork as long as we can?